### PR TITLE
Support JSON responses

### DIFF
--- a/app/controllers/resources/Accept.java
+++ b/app/controllers/resources/Accept.java
@@ -1,0 +1,52 @@
+/* Copyright 2014-2017 Fabian Steeg, hbz. Licensed under the GPLv2 */
+
+package controllers.resources;
+
+import java.util.Collection;
+
+import play.api.http.MediaRange;
+
+/**
+ * Helper class for dealing with content negotiation for the `Accept` header.
+ * 
+ * @author Fabian Steeg (fsteeg)
+ *
+ */
+public class Accept {
+
+	private Accept() {
+		// static helper class, don't instantiate
+	}
+
+	enum Format {
+		JSON_LD("json", "application/json", "application/ld+json"), //
+		HTML("html", "text/html");
+
+		String[] types;
+		String queryParamString;
+
+		private Format(String format, String... types) {
+			this.queryParamString = format;
+			this.types = types;
+		}
+	}
+
+	/**
+	 * @param formatParam The requested format parameter
+	 * @param acceptedTypes The accepted types
+	 * @return The selected format for the given parameter and types
+	 */
+	public static String formatFor(String formatParam,
+			Collection<MediaRange> acceptedTypes) {
+		for (Format format : Format.values())
+			if (formatParam != null && format.queryParamString.equals(formatParam))
+				return formatParam;
+		for (MediaRange mediaRange : acceptedTypes)
+			for (Format format : Format.values())
+				for (String mimeType : format.types)
+					if (mediaRange.accepts(mimeType))
+						return format.queryParamString;
+		return Format.JSON_LD.queryParamString;
+	}
+
+}

--- a/app/controllers/resources/Application.java
+++ b/app/controllers/resources/Application.java
@@ -1,4 +1,4 @@
-/* Copyright 2014 Fabian Steeg, hbz. Licensed under the GPLv2 */
+/* Copyright 2014-2017 Fabian Steeg, hbz. Licensed under the GPLv2 */
 
 package controllers.resources;
 
@@ -145,6 +145,7 @@ public class Application extends Controller {
 	 * @param word A word, a concept from the hbz union catalog
 	 * @param corporation A corporation associated with the resource
 	 * @param raw A query string that's directly (unprocessed) passed to ES
+	 * @param format The response format ('html' or 'json')
 	 * @return The search results
 	 */
 	public static Promise<Result> search(final String q, final String person,
@@ -152,11 +153,13 @@ public class Application extends Controller {
 			final String publisher, final String issued, final String medium,
 			final int from, final int size, final String owner, String t, String sort,
 			boolean details, String set, String location, String word,
-			String corporation, String raw) {
+			String corporation, String raw, String format) {
+		addCorsHeader();
 		String uuid = session("uuid");
 		if (uuid == null)
 			session("uuid", UUID.randomUUID().toString());
-		String cacheId = String.format("%s-%s", uuid, request().uri());
+		String cacheId = String.format("%s-%s-%s", uuid, request().uri(),
+				Accept.formatFor(format, request().acceptedTypes()));
 		@SuppressWarnings("unchecked")
 		Promise<Result> cachedResult = (Promise<Result>) Cache.get(cacheId);
 		if (cachedResult != null)
@@ -170,25 +173,19 @@ public class Application extends Controller {
 		String query = form.data().get("q");
 		Promise<Result> result = okPromise(query != null ? query : q, person, name,
 				subject, id, publisher, issued, medium, from, size, owner, t, sort,
-				details, set, location, word, corporation, raw);
+				details, set, location, word, corporation, raw, format);
 		cacheOnRedeem(cacheId, result, ONE_HOUR);
 		return result;
 	}
 
 	/**
 	 * @param id The resource ID.
+	 * @param format The response format ('html' or 'json')
 	 * @return The details page for the resource with the given ID.
 	 */
-	public static Promise<Result> show(final String id) {
-		String prevNext = (String) Cache.get(session("uuid") + "-" + id);
-		if (prevNext != null) {
-			session("prev", prevNext.startsWith(",") ? "" : prevNext.split(",")[0]);
-			session("next", prevNext.endsWith(",") ? "" : prevNext.split(",")[1]);
-		} else {
-			Logger.warn("No pagination session data for {}", id);
-		}
+	public static Promise<Result> show(final String id, String format) {
 		return search("", "", "", "", id, "", "", "", 0, 1, "", "", "", true, "",
-				"", "", "", "");
+				"", "", "", "", format);
 	}
 
 	private static Promise<Result> okPromise(final String q, final String person,
@@ -196,10 +193,10 @@ public class Application extends Controller {
 			final String publisher, final String issued, final String medium,
 			final int from, final int size, final String owner, String t, String sort,
 			boolean details, String set, String location, String word,
-			String corporation, String raw) {
+			String corporation, String raw, String format) {
 		final Promise<Result> result = call(q, person, name, subject, id, publisher,
 				issued, medium, from, size, owner, t, sort, details, set, location,
-				word, corporation, raw);
+				word, corporation, raw, format);
 		return result.recover((Throwable throwable) -> {
 			Logger.error("Could not call Lobid", throwable);
 			flashError();
@@ -230,7 +227,7 @@ public class Application extends Controller {
 			final String publisher, final String issued, final String medium,
 			final int from, final int size, String owner, String t, String sort,
 			boolean showDetails, String set, String location, String word,
-			String corporation, String raw) {
+			String corporation, String raw, String format) {
 		final WSRequestHolder requestHolder =
 				Lobid.request(q, person, name, subject, id, publisher, issued, medium,
 						from, size, owner, t, sort, set, location, word, corporation, raw);
@@ -246,20 +243,28 @@ public class Application extends Controller {
 						response.getStatusText(), requestHolder.getUrl(),
 						requestHolder.getQueryParameters());
 			}
-			if (showDetails) {
-				String json = "";
-				JsonNode nodes = Json.parse(s);
-				if (nodes.isArray() && nodes.size() == 2) { // first: metadata
-					json = nodes.get(1).toString();
-				} else {
+			String responseFormat =
+					Accept.formatFor(format, request().acceptedTypes());
+			boolean htmlRequested =
+					responseFormat.equals(Accept.Format.HTML.queryParamString);
+			if (htmlRequested) {
+				if (showDetails) {
+					JsonNode nodes = Json.parse(s);
+					if (nodes.isArray() && nodes.size() == 2) { // first: metadata
+						return ok(details.render(CONFIG, nodes.get(1).toString(), id));
+					}
 					Logger.warn("No suitable data to show details for: {}", nodes);
 				}
-				return ok(details.render(CONFIG, json, id));
+				return ok(search.render(s, q, person, name, subject, id, publisher,
+						issued, medium, from, size, hits, owner, t, sort, set, location,
+						word, corporation, raw));
 			}
-			return ok(search.render(s, q, person, name, subject, id, publisher,
-					issued, medium, from, size, hits, owner, t, sort, set, location, word,
-					corporation, raw));
+			return ok(showDetails ? Lobid.getResource(id) : Json.parse(s));
 		});
+	}
+
+	private static void addCorsHeader() {
+		response().setHeader("Access-Control-Allow-Origin", "*");
 	}
 
 	private static void uncache(List<String> ids) {
@@ -371,7 +376,7 @@ public class Application extends Controller {
 			String routeUrl = routes.Application.search(q, person, name, subjectQuery,
 					id, publisher, issuedQuery, mediumQuery, from, size, ownerQuery,
 					typeQuery, sort(sort, subjectQuery), false, set, locationQuery, word,
-					corporation, rawQuery).url();
+					corporation, rawQuery, null).url();
 
 			String result = String.format(
 					"<li " + (current ? "class=\"active\"" : "")
@@ -621,7 +626,7 @@ public class Application extends Controller {
 	 */
 	public static Result context() {
 		response().setContentType("application/ld+json");
-		response().setHeader("Access-Control-Allow-Origin", "*");
+		addCorsHeader();
 		return ok(Play.application().resourceAsStream("context.jsonld"));
 	}
 }

--- a/app/controllers/resources/Application.java
+++ b/app/controllers/resources/Application.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.elasticsearch.common.geo.GeoPoint;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -259,7 +260,11 @@ public class Application extends Controller {
 						issued, medium, from, size, hits, owner, t, sort, set, location,
 						word, corporation, raw));
 			}
-			return ok(showDetails ? Lobid.getResource(id) : Json.parse(s));
+			JsonNode responseJson =
+					showDetails ? Lobid.getResource(id) : Json.parse(s);
+			String prettyJson = new ObjectMapper().writerWithDefaultPrettyPrinter()
+					.writeValueAsString(responseJson);
+			return ok(prettyJson).as("application/json; charset=utf-8");
 		});
 	}
 

--- a/app/views/details.scala.html
+++ b/app/views/details.scala.html
@@ -31,7 +31,10 @@
             <dl>
             @defining((doc\\"hbzId")(0).asOpt[String].getOrElse("--")){ id =>
               <dt>@tags.star_button(id) Titeldetails:
-              <a href="@Application.CONFIG.getString("hbz01.api")/@id">&nbsp;</a>
+              <small style='float:right'>
+              <a title="MAB-XML-Quelldaten anzeigen" href="@Application.CONFIG.getString("hbz01.api")/@id"><span class="glyphicon glyphicon-log-out"></span></a>
+              <a title="JSON-LD-Indexdaten anzeigen" href='@resources.routes.Application.show(id, "json")'><span class="glyphicon glyphicon-cog"></span></a>
+              </small>
               </dt>
               <dd>@tags.result_doc(Json.parse(Lobid.getResource(id).toString))</dd>
             }

--- a/conf/resources.routes
+++ b/conf/resources.routes
@@ -8,7 +8,7 @@ GET    /*path/                controllers.resources.Application.redirect(path: S
 # Home page
 GET    /resources                      controllers.resources.Application.index()
 GET    /resources/advanced              controllers.resources.Application.advanced()
-GET    /resources/search                controllers.resources.Application.search(q?="", person?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int?=0, size:Int?=15, owner?="", t?="", sort ?= "newest", details:Boolean?=false, set?="", location ?= "", word?="", corporation?="", raw?="")
+GET    /resources/search                controllers.resources.Application.search(q?="", person?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int?=0, size:Int?=15, owner?="", t?="", sort ?= "newest", details:Boolean?=false, set?="", location ?= "", word?="", corporation?="", raw?="", format ?= null)
 GET    /resources/facets                controllers.resources.Application.facets(q,person?="", name?="", subject?="", id?="", publisher?="", issued?="", medium ?= "", from:Int,size:Int,owner,t,field,sort,set?="", location?="", word?="", corporation?="", raw?="")
 
 GET    /resources/stars                 controllers.resources.Application.showStars(format?="", ids?="")
@@ -18,7 +18,7 @@ POST   /resources/stars/:id             controllers.resources.Application.star(i
 DELETE /resources/stars/:id             controllers.resources.Application.unstar(id)
 
 GET    /resources/context.jsonld        controllers.resources.Application.context()
-GET    /resources/:id                   controllers.resources.Application.show(id)
+GET    /resources/:id                   controllers.resources.Application.show(id, format ?= null)
 
 # Map static resources from the /public folder to the /assets URL path
 GET    /resources/assets/*file          controllers.Assets.at(path="/public", file)

--- a/test/tests/AcceptIntegrationTest.java
+++ b/test/tests/AcceptIntegrationTest.java
@@ -1,0 +1,85 @@
+/* Copyright 2014-2017 Fabian Steeg, hbz. Licensed under the GPLv2 */
+
+package tests;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.test.Helpers.GET;
+import static play.test.Helpers.contentType;
+import static play.test.Helpers.fakeApplication;
+import static play.test.Helpers.fakeRequest;
+import static play.test.Helpers.header;
+import static play.test.Helpers.route;
+import static play.test.Helpers.running;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import controllers.resources.Accept;
+import play.mvc.Result;
+import play.test.FakeRequest;
+
+/**
+ * Integration tests for functionality provided by the {@link Accept} class.
+ * 
+ * @author Fabian Steeg (fsteeg)
+ */
+@SuppressWarnings("javadoc")
+@RunWith(Parameterized.class)
+public class AcceptIntegrationTest {
+
+	// test data parameters, formatted as "input /*->*/ expected output"
+	@Parameters
+	public static Collection<Object[]> data() {
+		// @formatter:off
+		return Arrays.asList(new Object[][] {
+			// search, default format: JSON
+			{ fakeRequest(GET, "/resources/search?q=*"), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/search?q=*&format="), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/search?q=*&format=json"), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/search?q=*&format=whatever"), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/search?q=*").withHeader("Accept", "text/plain"), /*->*/ "application/json" }, 
+			// search, others formats as query param:
+			{ fakeRequest(GET, "/resources/search?q=*&format=html"), /*->*/ "text/html" }, 
+			// search, others formats via header:
+			{ fakeRequest(GET, "/resources/search?q=*").withHeader("Accept", "application/json"), /*->*/ "application/json" },
+			{ fakeRequest(GET, "/resources/search?q=*").withHeader("Accept", "text/html"), /*->*/ "text/html" },
+			// get, default format: JSON
+			{ fakeRequest(GET, "/resources/HT009507067"), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/HT009507067?format="), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/HT009507067?format=json"), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/HT009507067?format=whatever"), /*->*/ "application/json" }, 
+			{ fakeRequest(GET, "/resources/HT009507067").withHeader("Accept", "text/plain"), /*->*/ "application/json" },
+			// get, others formats as query param:
+			{ fakeRequest(GET, "/resources/HT009507067?format=html"), /*->*/ "text/html" }, 
+			// get, others formats via header:
+			{ fakeRequest(GET, "/resources/HT009507067").withHeader("Accept", "application/json"), /*->*/ "application/json" },
+			{ fakeRequest(GET, "/resources/HT009507067").withHeader("Accept", "text/html"), /*->*/ "text/html" }});
+	} // @formatter:on
+
+	private FakeRequest fakeRequest;
+	private String contentType;
+
+	public AcceptIntegrationTest(FakeRequest request, String contentType) {
+		this.fakeRequest = request;
+		this.contentType = contentType;
+	}
+
+	@Test
+	public void test() {
+		running(fakeApplication(), () -> {
+			Result result = route(fakeRequest);
+			assertThat(result).isNotNull();
+			assertThat(contentType(result)).isEqualTo(contentType);
+			if (contentType.equals("application/json")) {
+				assertThat(header("Access-Control-Allow-Origin", result))
+						.isEqualTo("*");
+			}
+		});
+	}
+
+}

--- a/test/tests/AcceptUnitTest.java
+++ b/test/tests/AcceptUnitTest.java
@@ -1,0 +1,80 @@
+/* Copyright 2014-2017 Fabian Steeg, hbz. Licensed under the GPLv2 */
+
+package tests;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static play.test.Helpers.fakeRequest;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import controllers.resources.Accept;
+import play.api.http.MediaRange;
+import play.api.mvc.Request;
+import play.mvc.Http.RequestBody;
+import play.test.FakeRequest;
+import scala.collection.JavaConversions;
+
+/**
+ * Unit tests for functionality provided by the {@link Accept} class.
+ * 
+ * @author Fabian Steeg (fsteeg)
+ */
+@SuppressWarnings("javadoc")
+@RunWith(Parameterized.class)
+public class AcceptUnitTest {
+
+	// test data parameters, formatted as "input /*->*/ expected output"
+	@Parameters
+	public static Collection<Object[]> data() {
+		// @formatter:off
+		return Arrays.asList(new Object[][] {
+			// neither supported header nor supported format given, return default:
+			{ fakeRequest(), null, /*->*/ "json" }, 
+			{ fakeRequest(), "", /*->*/ "json" }, 
+			{ fakeRequest(), "xml", /*->*/ "json" }, 
+			{ fakeRequest().withHeader("Accept", ""), null, /*->*/ "json" }, 
+			{ fakeRequest().withHeader("Accept", "text/plain"), null, /*->*/ "json" }, 
+			// no header, just format parameter:
+			{ fakeRequest(), "html", /*->*/ "html" },
+			{ fakeRequest(), "json", /*->*/ "json" },
+			// supported content types, no format parameter given:
+			{ fakeRequest().withHeader("Accept", "text/html"), null, /*->*/ "html" },
+			{ fakeRequest().withHeader("Accept", "application/json"), null, /*->*/ "json" },
+			{ fakeRequest().withHeader("Accept", "application/ld+json"), null, /*->*/ "json" },
+			// we pick the preferred content type:
+			{ fakeRequest().withHeader("Accept", "text/html,application/json"), null, /*->*/"html" },
+			{ fakeRequest().withHeader("Accept", "application/json,text/html"), null, /*->*/ "json" },
+			// format parameter overrides header:
+			{ fakeRequest().withHeader("Accept", "text/html"), "json", /*->*/ "json" }});
+	} // @formatter:on
+
+	private FakeRequest fakeRequest;
+	private String passedFormat;
+	private String expectedFormat;
+
+	public AcceptUnitTest(FakeRequest request, String givenFormat,
+			String expectedFormat) {
+		this.fakeRequest = request;
+		this.passedFormat = givenFormat;
+		this.expectedFormat = expectedFormat;
+	}
+
+	@Test
+	public void test() {
+		Request<RequestBody> request = fakeRequest.getWrappedRequest();
+		Collection<MediaRange> acceptedTypes =
+				JavaConversions.asJavaCollection(request.acceptedTypes());
+		String description =
+				String.format("resulting format for passedFormat=%s, acceptedTypes=%s",
+						passedFormat, acceptedTypes);
+		String result = Accept.formatFor(passedFormat, acceptedTypes);
+		assertThat(result).as(description).isEqualTo(expectedFormat);
+	}
+
+}

--- a/test/tests/AllTests.java
+++ b/test/tests/AllTests.java
@@ -14,7 +14,8 @@ import org.junit.runners.Suite.SuiteClasses;
  */
 @RunWith(Suite.class)
 @SuiteClasses({ ApplicationTest.class, InternalIntegrationTest.class,
-		ExternalIntegrationTest.class, InputStringsTest.class })
+		ExternalIntegrationTest.class, InputStringsTest.class, AcceptUnitTest.class,
+		AcceptIntegrationTest.class })
 public class AllTests {
 	//
 }

--- a/test/tests/InputStringsTest.java
+++ b/test/tests/InputStringsTest.java
@@ -83,7 +83,8 @@ public class InputStringsTest {
 		running(testServer(3333), () -> {
 			Result result = Helpers.callAction(
 					controllers.resources.routes.ref.Application.search(input, "", "", "",
-							"", "", "", "", 0, 10, "", "", "", false, "", "", "", "", ""),
+							"", "", "", "", 0, 10, "", "", "", false, "", "", "", "", "",
+							null),
 					new FakeRequest(Helpers.GET, "/")
 							.withFormUrlEncodedBody(ImmutableMap.of()));
 			// we don't expect any server errors (see

--- a/test/tests/TravisTests.java
+++ b/test/tests/TravisTests.java
@@ -13,7 +13,8 @@ import org.junit.runners.Suite.SuiteClasses;
  *
  */
 @RunWith(Suite.class)
-@SuiteClasses({ ApplicationTest.class, InternalIntegrationTest.class })
+@SuiteClasses({ ApplicationTest.class, InternalIntegrationTest.class,
+		AcceptUnitTest.class })
 public class TravisTests {
 	//
 }


### PR DESCRIPTION
Will resolve #5. Behavior is like in lobid-organisations:

Default (no param, no header) is JSON:

`curl http://alpha.lobid.org/resources/HT019116616`

Request HTML by header:

`curl -H "Accept: text/html" http://alpha.lobid.org/resources/HT019116616`

That's what happens in the browser:

http://alpha.lobid.org/resources/HT019116616

Request JSON with param, e.g. for JSON in the browser:

http://alpha.lobid.org/resources/HT019116616?format=json

All responses have a `Access-Control-Allow-Origin` (CORS) header:

`curl -I http://alpha.lobid.org/resources/HT019116616`